### PR TITLE
feat(loader): Use `@babel/core` parser.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   },
   "dependencies": {
     "@babel/generator": "^7.0.0",
-    "@babel/parser": "^7.1.0",
     "@babel/traverse": "^7.1.0",
     "@babel/types": "^7.0.0",
     "loader-utils": "^1.1.0"

--- a/src/code-split.js
+++ b/src/code-split.js
@@ -1,4 +1,4 @@
-import {parse} from '@babel/parser';
+import {parse} from '@babel/core';
 import traverse from '@babel/traverse';
 import generate from '@babel/generator';
 import {callExpression, expressionStatement} from '@babel/types';
@@ -200,8 +200,16 @@ const isHydratable = (hydratablePropPath)=> (
 );
 
 
-export const getModule = (source)=> {
-  const ast = parse(source, {sourceType: 'module'});
+const getAst = (source, inputSourceMap)=> (
+  parse(source, {
+    sourceType: 'module',
+    inputSourceMap
+  })
+);
+
+
+export const getModule = (source, sourceMap)=> {
+  const ast = getAst(source, sourceMap);
 
   const moduleComponent = getModuleComponent(ast);
   const {onLoad, children} = getProps(moduleComponent);
@@ -219,8 +227,8 @@ export const getModule = (source)=> {
 };
 
 
-export const getTemplate = (source)=> {
-  const ast = parse(source, {sourceType: 'module'});
+export const getTemplate = (source, sourceMap)=> {
+  const ast = getAst(source, sourceMap);
 
   const moduleComponent = getModuleComponent(ast);
   const {onLoad, hydratable, children} = getProps(moduleComponent);

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const createLoader = (loaderCtx)=> async (source, sourceMap, meta)=> {
   const {output, ...props} = getOptions(loaderCtx);
 
   const template = getTemplate(source, sourceMap);
-
+  // TODO: add all file dependencies to weback to ensure rebuilds upon changes
   getTemplateHandler(loaderCtx)({output, template, props});
 
   const {code, map} = getModule(source, sourceMap);

--- a/src/template.js
+++ b/src/template.js
@@ -34,7 +34,9 @@ const getRequire = (parentContext, compilation, exec)=> (req)=> {
 
 
 const exec = (context, filename, source, compilation)=> {
-  const {code} = transform(source);
+  // we need to transform import and export statements that might be
+  // used in webpack compiled modules
+  const {code} = transform(source, {filename});
 
   const module = {exports: {}};
 


### PR DESCRIPTION
Using the core parser supports source-maps and will pick up local babel config. This should make
template code a bit easier to work with.