### PR TITLE
fix(loader): Fix VariableDeclarator removal.

### DIFF
--- a/src/code-split.js
+++ b/src/code-split.js
@@ -110,13 +110,20 @@ function* getDependentPaths(...paths) {
 
 /**
  * Remove the `path` and its parents.
- * Only remove parent `ImportDeclarations` if `path` is the last
+ * Only remove parent `ImportDeclaration`s if `path` is the last
  * `ImportSpecifier`.
+ * Only remove parent `VariableDeclaration`s if `path` is the last
+ * `Variable`.
  */
 const removePathAndMaybeParent = (path)=> {
   const {parentPath} = path;
 
   if (isAnyImportSpecifier(path) && parentPath.node.specifiers.length > 1) {
+    path.remove();
+    return;
+  }
+
+  if (path.isVariableDeclarator() && parentPath.node.declarations.length > 1) {
     path.remove();
     return;
   }

--- a/src/code-split.test.js
+++ b/src/code-split.test.js
@@ -27,7 +27,6 @@ describe('App rendered at runtime', ()=> {
 
     const foo = 'needed by app';
 
-
     const Html = ({scripts, styles})=> (
       <html>
         <head>
@@ -222,6 +221,29 @@ describe('no child to render', ()=> {
       );
 
       export default Html;
+    `);
+  });
+});
+
+
+describe('path removal issues', ()=> {
+  it('removes variable declarations only if they would be empty', ()=> {
+    const {code} = getModule(jsx`
+      import React from 'react';
+      import {Module, Scripts} from 'react-entry-loader/injectors';
+
+      const foo = 1, bar = '2';
+
+      const Html = ({scripts})=> (
+        <Module onLoad={()=> foo} />
+      );
+
+      export default Html;
+    `);
+
+    expect(code).toBe(jsx`
+      const foo = 1;
+      (() => foo)();
     `);
   });
 });


### PR DESCRIPTION
When having `const a=1, b=2;` the declaration should only be removed when the last declarator is
being removed.