### PR TITLE
fix(template): Un-escape single quotes for CSP meta tags.

### DIFF
--- a/examples/page1.js
+++ b/examples/page1.js
@@ -12,6 +12,10 @@ const Html = ({scripts, styles, title})=> (
   <html>
     <head>
       <title>{title}</title>
+      <meta
+        httpEquiv="Content-Security-Policy"
+        content="default-src 'self';"
+      />
       <Styles files={styles} />
       <Scripts files={scripts} async />
     </head>

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -45,6 +45,10 @@ describe('loader and plugin', ()=> {
       <html data-reactroot="">
         <head>
           <title>react-entry-loader - page 1</title>
+          <meta
+            http-equiv="Content-Security-Policy"
+            content="default-src 'self';"
+          />
           <link href="shared.css" rel="stylesheet"/>
           <script type="text/javascript" src="runtime.js" async=""></script>
           <script type="text/javascript" src="shared.js" async=""></script>

--- a/src/template.js
+++ b/src/template.js
@@ -7,6 +7,14 @@ import {transform} from '@babel/core';
 import React from 'react';
 import ReactDomServer from 'react-dom/server';
 
+// TODO: Workaround for un-escaping characters that should appear as is in HTML.
+const sanitize = (html)=> (
+  // un-escape `'` that is required in CSP meta tags.
+  html.replace(
+    /(<meta .+?"Content-Security-Policy".+?content=")(.+?)(".*?\/>)/g,
+    (_, start, policy, end)=> `${start}${policy.replace(/&#x27;/g, "'")}${end}`
+  )
+);
 
 const getRequire = (parentContext, compilation, exec)=> (req)=> {
   // TODO: needed for tests to be able to import react-entry-loader
@@ -67,7 +75,7 @@ const getRunner = (compilation)=> async (filename, context, {code}, props)=> {
   const html = ReactDomServer.renderToString(
     React.createElement(Html, props)
   );
-  return `<!DOCTYPE html>${html}`;
+  return sanitize(`<!DOCTYPE html>${html}`);
 };
 
 export default getRunner;


### PR DESCRIPTION
React escapes single quotes as `&#x27;`. This does not work for CSP meta tags. The template renderer
now un-escapes all CSP meta tag's content attributes.