### PR TITLE
fix(loader): Handle null sourcemaps.

### DIFF
--- a/src/code-split.js
+++ b/src/code-split.js
@@ -207,10 +207,10 @@ const isHydratable = (hydratablePropPath)=> (
 );
 
 
-const getAst = (source, inputSourceMap)=> (
+const getAst = (source, sourceMap)=> (
   parse(source, {
     sourceType: 'module',
-    inputSourceMap
+    inputSourceMap: sourceMap || false
   })
 );
 


### PR DESCRIPTION
Webpack may send `null` as sourcemaps, which is now treated as no sourcmap instead of failing.