### PR TITLE
fix(code-split): Remove sourcemaps to work around missing sourceFileName

### DIFF
--- a/src/code-split.js
+++ b/src/code-split.js
@@ -248,5 +248,5 @@ export const getTemplate = (source, sourceMap)=> {
     removePaths(...children);
   }
 
-  return generate(ast, {sourceMaps: true}, source);
+  return generate(ast, {sourceMaps: false}, source);
 };


### PR DESCRIPTION
`@babel/generator@7.8` throws an error when trying to access `sourceFileName` which is not provided on the option param to `generate`. 
Disabling sourcemaps will at least make things work and allow react-entry-loader to be used with later versions of `@babel/generator`.