### PR TITLE
ci($release): Change package name to something we own

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-entry-loader",
+  "name": "@nearmap/react-entry-loader",
   "description": "Use a webpack entry module as a template to generate HTML assets.",
   "keywords": [
     "webpack",


### PR DESCRIPTION
We can't publish to the react-entry-loader package on npm since it is not owned by nearmap. This
changes the package name so we can publish.